### PR TITLE
Render con failures as actual typechecking errors

### DIFF
--- a/skeletest.cabal
+++ b/skeletest.cabal
@@ -79,6 +79,7 @@ library
     , containers
     , Diff >= 1.0
     , directory
+    , exceptions
     , filepath
     , ghc ^>= 9.8 || ^>= 9.10 || ^>= 9.12
     , hedgehog

--- a/src/Skeletest/Internal/Error.hs
+++ b/src/Skeletest/Internal/Error.hs
@@ -10,13 +10,11 @@ module Skeletest.Internal.Error (
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC qualified
-import GHC.Utils.Outputable qualified as GHC
-import GHC.Utils.Panic (pgmError)
 import UnliftIO.Exception (Exception (..), impureThrow)
 
 data SkeletestError
   = -- | A user error during compilation, e.g. during the preprocessor or plugin phases.
-    CompilationError Text
+    CompilationError (Maybe GHC.SrcSpan) Text
   | -- | An error in a situation that should never happen, and indicates a bug.
     InvariantViolation Text
   | TestInfoNotFound
@@ -28,7 +26,7 @@ data SkeletestError
 instance Exception SkeletestError where
   displayException =
     Text.unpack . \case
-      CompilationError msg ->
+      CompilationError _ msg ->
         Text.unlines
           [ ""
           , "******************** skeletest failure ********************"
@@ -49,15 +47,7 @@ instance Exception SkeletestError where
         "Snapshot file was corrupted: " <> Text.pack fp
 
 skeletestPluginError :: Maybe GHC.SrcSpan -> String -> a
-skeletestPluginError mloc = pgmError . addLoc . stripEnd . displayException . CompilationError . Text.pack
-  where
-    stripEnd = Text.unpack . Text.stripEnd . Text.pack
-
-    -- https://gitlab.haskell.org/ghc/ghc/-/issues/25816
-    addLoc s =
-      case mloc of
-        Nothing -> s
-        Just loc -> s <> "\n    at " <> (GHC.showSDocUnsafe . GHC.ppr) loc
+skeletestPluginError mloc = impureThrow . CompilationError mloc . Text.pack
 
 invariantViolation :: String -> a
 invariantViolation = impureThrow . InvariantViolation . Text.pack

--- a/src/Skeletest/Internal/GHC.hs
+++ b/src/Skeletest/Internal/GHC.hs
@@ -52,6 +52,7 @@ module Skeletest.Internal.GHC (
   getHsName,
 ) where
 
+import Control.Monad.Catch (handleJust)
 import Control.Monad.Trans.Class qualified as Trans
 import Control.Monad.Trans.State (StateT, evalStateT)
 import Control.Monad.Trans.State qualified as State
@@ -74,10 +75,12 @@ import GHC (
 import GHC qualified
 import GHC.Driver.Main qualified as GHC
 import GHC.Plugins qualified as GHC hiding (getHscEnv)
+import GHC.Tc.Errors.Types qualified as GHC
 import GHC.Tc.Utils.Monad qualified as GHC
 import GHC.Types.Name qualified as GHC.Name
 import GHC.Types.Name.Cache qualified as GHC (NameCache)
 import GHC.Types.SourceText qualified as GHC.SourceText
+import GHC.Utils.Error qualified as GHC
 import Language.Haskell.TH.Syntax qualified as TH
 import System.IO.Unsafe (unsafePerformIO)
 
@@ -85,7 +88,10 @@ import System.IO.Unsafe (unsafePerformIO)
 import Data.Foldable (foldl')
 #endif
 
-import Skeletest.Internal.Error (invariantViolation)
+import Skeletest.Internal.Error (
+  SkeletestError (CompilationError),
+  invariantViolation,
+ )
 import Skeletest.Internal.GHC.Compat (genLoc)
 import Skeletest.Internal.GHC.Compat qualified as GHC.Compat
 
@@ -374,7 +380,18 @@ newtype CompileRn a = CompileRn (StateT (Map Text GHC.Name) GHC.TcM a)
   deriving (Functor, Applicative, Monad)
 
 runCompileRn :: CompileRn a -> GHC.TcM a
-runCompileRn (CompileRn m) = evalStateT m Map.empty
+runCompileRn (CompileRn m) = handleCompilationError $ evalStateT m Map.empty
+  where
+    handleCompilationError =
+      handleJust
+        ( \case
+            CompilationError mloc msg -> Just $ do
+              GHC.failAt (fromMaybe GHC.noSrcSpan mloc) $ mkTcError msg
+            _ -> Nothing
+        )
+        id
+
+    mkTcError = GHC.mkTcRnUnknownMessage . GHC.mkPlainError GHC.noHints . GHC.text . Text.unpack
 
 instance MonadHasNameCache CompileRn where
   getNameCache = GHC.hsc_NC . GHC.env_top <$> (CompileRn . Trans.lift) GHC.getEnv

--- a/src/Skeletest/Internal/Plugin.hs
+++ b/src/Skeletest/Internal/Plugin.hs
@@ -139,7 +139,7 @@ replaceConMatch ctx e =
         HsExprCon conName -> convertPrefixCon conName []
         HsExprApps (getExpr -> HsExprCon conName) preds -> convertPrefixCon conName preds
         HsExprRecordCon conName fields -> convertRecordCon conName fields
-        _ -> skeletestPluginError (getLoc con) "P.con must be applied to a constructor"
+        _ -> skeletestPluginError (getLoc e) "P.con must be applied to a constructor"
     convertPrefixCon conName preds =
       let
         exprNames = mkVarNames preds

--- a/src/Skeletest/Internal/Preprocessor.hs
+++ b/src/Skeletest/Internal/Preprocessor.hs
@@ -104,7 +104,7 @@ insertImports :: [(FilePath, Text)] -> Text -> Either SkeletestError Text
 insertImports testModules file =
   let (pre, post) = break isSkeletestImport $ Text.lines file
    in if null post
-        then Left $ CompilationError "Could not find Skeletest.Main import in Main module"
+        then Left $ CompilationError Nothing "Could not find Skeletest.Main import in Main module"
         else pure . Text.unlines $ pre <> importTests <> post
   where
     isSkeletestImport line =

--- a/test/Skeletest/__snapshots__/PredicateSpec.snap.md
+++ b/test/Skeletest/__snapshots__/PredicateSpec.snap.md
@@ -197,31 +197,29 @@ Got:
 ## Data types / con / fails to compile when applied to multiple arguments
 
 ```
-<no location info>: error:
-    
-******************** skeletest failure ********************
-P.con must be applied to exactly one argument
-    at ExampleSpec.hs:7:22-30
+ExampleSpec.hs:7:22: error:
+    P.con must be applied to exactly one argument
+  |
+7 |   "" `shouldSatisfy` P.con 1 2
+  |                      ^^^^^^^^^
 ```
 
 ## Data types / con / fails to compile when not applied to anything
 
 ```
-<no location info>: error:
-    
-******************** skeletest failure ********************
-P.con must be applied to a constructor
-    at ExampleSpec.hs:7:22-26
+ExampleSpec.hs:7:22: error: P.con must be applied to a constructor
+  |
+7 |   "" `shouldSatisfy` P.con
+  |                      ^^^^^
 ```
 
 ## Data types / con / fails to compile with non-constructor
 
 ```
-<no location info>: error:
-    
-******************** skeletest failure ********************
-P.con must be applied to a constructor
-    at ExampleSpec.hs:7:28-29
+ExampleSpec.hs:7:22: error: P.con must be applied to a constructor
+  |
+7 |   "" `shouldSatisfy` P.con ""
+  |                      ^^^^^^^^
 ```
 
 ## Data types / con / fails to compile with omitted positional fields


### PR DESCRIPTION
Now `P.con` errors look like native typechecking errors 🎉 