### PR TITLE
Fix gray color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Runtime changes:
+* Fix gray text output, using standard ANSI codes instead of a hardcoded RGB value
+
 ## v0.3.2
 
 API changes:

--- a/skeletest.cabal
+++ b/skeletest.cabal
@@ -81,7 +81,6 @@ library
     , aeson
     , aeson-pretty
     , ansi-terminal >= 0.7.0
-    , colour
     , containers
     , Diff >= 1.0
     , directory

--- a/src/Skeletest/Internal/Utils/Color.hs
+++ b/src/Skeletest/Internal/Utils/Color.hs
@@ -5,7 +5,6 @@ module Skeletest.Internal.Utils.Color (
   gray,
 ) where
 
-import Data.Colour.Names qualified as Color
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.Console.ANSI qualified as ANSI
@@ -23,4 +22,4 @@ yellow :: Text -> Text
 yellow = withANSI [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
 
 gray :: Text -> Text
-gray = withANSI [ANSI.SetRGBColor ANSI.Foreground Color.gray]
+gray = withANSI [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Black]


### PR DESCRIPTION
We were previously hardcoding gray to `RGB(128,128,128)`, which might look off in different Terminal themes. Changed to `Vivid Black`, which is part of the theme the user chooses.

Before:
<img width="385" height="133" alt="Screenshot 2026-02-04 at 5 35 59 PM" src="https://github.com/user-attachments/assets/9e9405a3-179b-43a5-980e-07d9f71f1117" />

After:
<img width="370" height="114" alt="Screenshot 2026-02-04 at 5 37 21 PM" src="https://github.com/user-attachments/assets/a43d8d16-74d4-4188-9ecf-252d2c70308f" />
