### PR TITLE
Explicitly fail if configuring after forAll/IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Runtime changes:
 * Render exceptions in property tests the same as unit tests
+* If property configuration (e.g. `Prop.setDiscardLimit`) occurs after `forAll` or IO actions, it now errors instead of silently being ignored
 
 ## v0.3.5
 

--- a/src/Skeletest/Internal/Error.hs
+++ b/src/Skeletest/Internal/Error.hs
@@ -20,6 +20,7 @@ data SkeletestError
   | CliFlagNotFound Text
   | FixtureCircularDependency [Text]
   | SnapshotFileCorrupted FilePath
+  | PropConfigAfterIO
   deriving (Show)
 
 instance Exception SkeletestError where
@@ -42,6 +43,8 @@ instance Exception SkeletestError where
         "Found circular dependency when resolving fixtures: " <> Text.intercalate " -> " fixtures
       SnapshotFileCorrupted fp ->
         "Snapshot file was corrupted: " <> Text.pack fp
+      PropConfigAfterIO ->
+        "Property configuration function must be done before any forAll or IO actions"
 
 skeletestPluginError :: Maybe GHC.SrcSpan -> String -> a
 skeletestPluginError mloc = impureThrow . CompilationError mloc . Text.pack

--- a/src/Skeletest/Prop/Internal.hs
+++ b/src/Skeletest/Prop/Internal.hs
@@ -49,6 +49,7 @@ import Hedgehog.Internal.Runner qualified as Hedgehog
 import Hedgehog.Internal.Seed qualified as Hedgehog.Seed
 import Hedgehog.Internal.Source qualified as Hedgehog
 import Skeletest.Internal.CLI (FlagSpec (..), IsFlag (..), getFlag)
+import Skeletest.Internal.Error (SkeletestError (..))
 import Skeletest.Internal.TestInfo (TestInfo, getTestInfo)
 import Skeletest.Internal.TestRunner (
   AssertionFail (..),
@@ -62,7 +63,7 @@ import Skeletest.Internal.TestRunner (
  )
 import Skeletest.Internal.Utils.Color qualified as Color
 import Text.Read (readEither, readMaybe)
-import UnliftIO.Exception (SomeException, fromException, toException)
+import UnliftIO.Exception (SomeException, fromException, throwIO, toException)
 import UnliftIO.IORef (IORef, newIORef, readIORef, writeIORef)
 
 #if !MIN_VERSION_base(4, 20, 0)
@@ -98,7 +99,8 @@ instance Monad PropertyM where
     PropertyIO cfg1 $ do
       a <- fa
       case k a of
-        PropertyPure _ b -> pure b
+        PropertyPure [] b -> pure b
+        PropertyPure _ _ -> throwIO PropConfigAfterIO
         PropertyIO _ mb -> mb
 instance MonadIO PropertyM where
   liftIO = PropertyIO [] . liftIO

--- a/test/Skeletest/PropSpec.hs
+++ b/test/Skeletest/PropSpec.hs
@@ -33,7 +33,7 @@ spec = do
         , "  displayException MyException = \"this is MyException\""
         ]
 
-      (stdout, stderr) <- expectFailure $ runner.runTestsWith def{cliArgs = ["--seed=0:0"]}
+      (stdout, stderr) <- expectFailure $ runner.runTestsWith zeroSeed
       stderr `shouldBe` ""
       sanitizeTraceback stdout `shouldSatisfy` P.matchesSnapshot
 
@@ -56,7 +56,44 @@ spec = do
         , "  flagSpec = RequiredFlag (const $ Right MyFlag)"
         ]
 
-      (stdout, stderr) <- expectFailure $ runner.runTestsWith def{cliArgs = ["--seed=0:0"]}
+      (stdout, stderr) <- expectFailure $ runner.runTestsWith zeroSeed
+      stderr `shouldBe` ""
+      stdout `shouldSatisfy` P.matchesSnapshot
+
+    integration . it "fails when configuration occurs after forAll" $ do
+      runner <- getFixture @TestRunner
+      runner.addTestFile "ExampleSpec.hs" $
+        [ "module ExampleSpec (spec) where"
+        , ""
+        , "import Skeletest"
+        , "import qualified Skeletest.Prop as Prop"
+        , "import qualified Skeletest.Prop.Gen as Gen"
+        , ""
+        , "spec = prop \"discards\" $ do"
+        , "  x <- forAll Gen.bool"
+        , "  Prop.setDiscardLimit 10"
+        , "  x `shouldBe` x"
+        ]
+
+      (stdout, stderr) <- expectFailure $ runner.runTestsWith zeroSeed
+      stderr `shouldBe` ""
+      stdout `shouldSatisfy` P.matchesSnapshot
+
+    integration . it "fails when configuration occurs after IO actions" $ do
+      runner <- getFixture @TestRunner
+      runner.addTestFile "ExampleSpec.hs" $
+        [ "module ExampleSpec (spec) where"
+        , ""
+        , "import Skeletest"
+        , "import qualified Skeletest.Prop as Prop"
+        , "import qualified Skeletest.Prop.Gen as Gen"
+        , ""
+        , "spec = prop \"discards\" $ do"
+        , "  FixtureTmpDir _ <- getFixture"
+        , "  Prop.setDiscardLimit 10"
+        ]
+
+      (stdout, stderr) <- expectFailure $ runner.runTestsWith zeroSeed
       stderr `shouldBe` ""
       stdout `shouldSatisfy` P.matchesSnapshot
 
@@ -100,6 +137,9 @@ spec = do
         , "    (read . show) P.=== id `shouldNotSatisfy` P.isoWith (Gen.int $ Range.linear 0 10)"
         ]
 
-      (stdout, stderr) <- expectFailure $ runner.runTestsWith def{cliArgs = ["--seed=0:0"]}
+      (stdout, stderr) <- expectFailure $ runner.runTestsWith zeroSeed
       stderr `shouldBe` ""
       stdout `shouldSatisfy` P.matchesSnapshot
+
+zeroSeed :: TestArgs
+zeroSeed = def{cliArgs = ["--seed=0:0"]}

--- a/test/Skeletest/__snapshots__/PropSpec.snap.md
+++ b/test/Skeletest/__snapshots__/PropSpec.snap.md
@@ -38,6 +38,30 @@
 ╰────────────────────────────────────────────────────────────────────────────────────────
 ```
 
+## prop / fails when configuration occurs after IO actions
+
+```
+./ExampleSpec.hs
+╭── discards: ERROR
+│ Property configuration function must be done before any forAll or IO actions
+│ 
+│ Failed after 1 tests.
+│ Rerun with --seed=0:0 to reproduce.
+╰───────────────────────────────────────────────────────────────────────────────
+```
+
+## prop / fails when configuration occurs after forAll
+
+```
+./ExampleSpec.hs
+╭── discards: ERROR
+│ Property configuration function must be done before any forAll or IO actions
+│ 
+│ Failed after 1 tests.
+│ Rerun with --seed=0:0 to reproduce.
+╰───────────────────────────────────────────────────────────────────────────────
+```
+
 ## prop / renders Skeletest errors well
 
 ```


### PR DESCRIPTION
Previously, we would just silently ignore configuration done after forAll/IO. We should error instead, so it's more obvious.